### PR TITLE
Support tools in multiple frames and modernize API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Chrome Extension that allows developers to inspect, monitor, and execute tools
 
 ## Prerequisites
 
-**Important:** This extension relies on the experimental `navigator.modelContextTesting` Web API. You must enable the "WebMCP for testing" flag in `chrome://flags` to turn it on in Chrome 146.0.7672.0 or higher.
+**Important:** This extension relies on the experimental `navigator.modelContextTesting` Web API. You must enable the "WebMCP for testing" flag in `chrome://flags` to turn it on in Chrome 148.0.7778.56 or higher.
 
 ## Installation
 

--- a/background.js
+++ b/background.js
@@ -12,7 +12,7 @@ chrome.runtime.onInstalled.addListener(async () => {
   tabs.forEach(({ id: tabId }) => {
     chrome.scripting
       .executeScript({
-        target: { tabId },
+        target: { tabId, allFrames: true },
         files: ['content.js'],
       })
       .catch(() => {});

--- a/background.js
+++ b/background.js
@@ -28,7 +28,7 @@ async function updateBadge(tabId) {
   if (tab.id !== tabId) return;
   chrome.action.setBadgeText({ text: '', tabId });
   chrome.action.setBadgeBackgroundColor({ color: '#2563eb' });
-  chrome.tabs.sendMessage(tabId, { action: 'LIST_TOOLS' }).catch(({ message }) => {
+  chrome.tabs.sendMessage(tabId, { action: 'LIST_TOOLS' }, { frameId: 0 }).catch(({ message }) => {
     chrome.runtime.sendMessage({ message });
   });
 }

--- a/content.js
+++ b/content.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-console.debug('[WebMCP] Content script injected');
+console.debug(`[WebMCP] Content script injected in ${location.href}`);
 
-chrome.runtime.onMessage.addListener(({ action, name, inputArgs }, _, reply) => {
+chrome.runtime.onMessage.addListener(({ action, name, inputArgs, location }, _, reply) => {
   try {
     if (!navigator.modelContextTesting) {
       throw new Error('Error: You must run Chrome with the "WebMCP for testing" flag enabled.');
@@ -23,7 +23,8 @@ chrome.runtime.onMessage.addListener(({ action, name, inputArgs }, _, reply) => 
       navigator.modelContextTesting.registerToolsChangedCallback(listTools);
     }
     if (action == 'EXECUTE_TOOL') {
-      console.debug(`[WebMCP] Execute tool "${name}" with`, inputArgs);
+      if (location && location !== window.location.href) return;
+      console.debug(`[WebMCP] Execute tool "${name}" with ${inputArgs} in ${location}`);
       let targetFrame, loadPromise;
       // Check if this tool is associated with a form target
       const formTarget = document.querySelector(`form[toolname="${name}"]`)?.target;
@@ -34,6 +35,26 @@ chrome.runtime.onMessage.addListener(({ action, name, inputArgs }, _, reply) => 
         });
       }
       // Execute the experimental tool
+      if ('executeTool' in navigator.modelContext) {
+        navigator.modelContext
+          .getTools()
+          .then(async (tools) => {
+            const tool = tools.find((t) => t.name === name && t.window.location.href === location);
+            let result = await navigator.modelContext.executeTool(tool, inputArgs);
+            // If result is null and we have a target frame, wait for the frame to reload.
+            if (result === null && targetFrame) {
+              console.debug(`[WebMCP] Waiting for form target ${targetFrame} to load`);
+              await loadPromise;
+              console.debug('[WebMCP] Get cross document script tool result');
+              result = targetFrame.contentWindow.document.querySelector(
+                'script[type="application/ld+json"]',
+              )?.textContent;
+            }
+            reply(result);
+          })
+          .catch(({ message }) => reply(JSON.stringify(message)));
+        return true;
+      }
       const promise = navigator.modelContextTesting.executeTool(name, inputArgs);
       promise
         .then(async (result) => {
@@ -42,8 +63,9 @@ chrome.runtime.onMessage.addListener(({ action, name, inputArgs }, _, reply) => 
             console.debug(`[WebMCP] Waiting for form target ${targetFrame} to load`);
             await loadPromise;
             console.debug('[WebMCP] Get cross document script tool result');
-            result =
-              await targetFrame.contentWindow.navigator.modelContextTesting.getCrossDocumentScriptToolResult();
+            result = targetFrame.contentWindow.document.querySelector(
+              'script[type="application/ld+json"]',
+            )?.textContent;
           }
           reply(result);
         })
@@ -51,10 +73,9 @@ chrome.runtime.onMessage.addListener(({ action, name, inputArgs }, _, reply) => 
       return true;
     }
     if (action == 'GET_CROSS_DOCUMENT_SCRIPT_TOOL_RESULT') {
-      console.debug('[WebMCP] Get cross document script tool result');
-      const promise = navigator.modelContextTesting.getCrossDocumentScriptToolResult();
-      promise.then(reply).catch(({ message }) => reply(JSON.stringify(message)));
-      return true;
+      if (location && !window.location.href.startsWith(location)) return;
+      console.debug(`[WebMCP] Get cross document script tool result in ${location}`);
+      reply(document.querySelector('script[type="application/ld+json"]')?.textContent);
     }
   } catch ({ message }) {
     chrome.runtime.sendMessage({ message });
@@ -65,6 +86,14 @@ async function listTools() {
   let tools;
   if ('getTools' in navigator.modelContext) {
     tools = await navigator.modelContext.getTools();
+    tools = tools.map((tool) => {
+      return {
+        description: tool.description,
+        name: tool.name,
+        inputSchema: tool.inputSchema,
+        location: tool.window.location.href,
+      };
+    });
   } else {
     tools = navigator.modelContextTesting.listTools();
   }

--- a/content.js
+++ b/content.js
@@ -16,11 +16,7 @@ chrome.runtime.onMessage.addListener(({ action, name, inputArgs, location }, _, 
         navigator.modelContext.addEventListener('toolchange', listTools);
         return;
       }
-      if ('ontoolchange' in navigator.modelContextTesting) {
-        navigator.modelContextTesting.addEventListener('toolchange', listTools);
-        return;
-      }
-      navigator.modelContextTesting.registerToolsChangedCallback(listTools);
+      navigator.modelContextTesting.addEventListener('toolchange', listTools);
     }
     if (action == 'EXECUTE_TOOL') {
       if (location && location !== window.location.href) return;

--- a/content.js
+++ b/content.js
@@ -35,27 +35,15 @@ chrome.runtime.onMessage.addListener(({ action, name, inputArgs, location }, _, 
         });
       }
       // Execute the experimental tool
+      let promise;
       if ('executeTool' in navigator.modelContext) {
-        navigator.modelContext
-          .getTools()
-          .then(async (tools) => {
-            const tool = tools.find((t) => t.name === name && t.window.location.href === location);
-            let result = await navigator.modelContext.executeTool(tool, inputArgs);
-            // If result is null and we have a target frame, wait for the frame to reload.
-            if (result === null && targetFrame) {
-              console.debug(`[WebMCP] Waiting for form target ${targetFrame} to load`);
-              await loadPromise;
-              console.debug('[WebMCP] Get cross document script tool result');
-              result = targetFrame.contentWindow.document.querySelector(
-                'script[type="application/ld+json"]',
-              )?.textContent;
-            }
-            reply(result);
-          })
-          .catch(({ message }) => reply(JSON.stringify(message)));
-        return true;
+        promise = navigator.modelContext.getTools().then((tools) => {
+          const tool = tools.find((t) => t.name === name && t.window.location.href === location);
+          return navigator.modelContext.executeTool(tool, inputArgs);
+        });
+      } else {
+        promise = navigator.modelContextTesting.executeTool(name, inputArgs);
       }
-      const promise = navigator.modelContextTesting.executeTool(name, inputArgs);
       promise
         .then(async (result) => {
           // If result is null and we have a target frame, wait for the frame to reload.

--- a/content.js
+++ b/content.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-console.debug(`[WebMCP] Content script injected in ${location.href}`);
+console.debug(`[WebMCP] Content script injected in ${window.location.href}`);
 
 chrome.runtime.onMessage.addListener(({ action, name, inputArgs, location }, _, reply) => {
   try {
@@ -71,25 +71,51 @@ chrome.runtime.onMessage.addListener(({ action, name, inputArgs, location }, _, 
 });
 
 async function listTools() {
-  let tools;
+  let tools = [];
   if ('getTools' in navigator.modelContext) {
-    tools = await navigator.modelContext.getTools();
-    tools = tools.map((tool) => {
-      return {
+    for (const tool of await navigator.modelContext.getTools()) {
+      let location;
+      try {
+        location = tool.window.location.href;
+      } catch {
+        location = await getLocation(tool.window);
+      }
+      tools.push({
         description: tool.description,
         inputSchema: tool.inputSchema,
         readOnlyHint: tool.annotations?.readOnlyHint ? '✓' : undefined,
         untrustedContentHint: tool.annotations?.untrustedContentHint ? '✓' : undefined,
         name: tool.name,
-        location: tool.window.location.href,
-      };
-    });
+        location,
+      });
+    }
   } else {
     tools = navigator.modelContextTesting.listTools();
   }
   console.debug(`[WebMCP] Got ${tools.length} tools`, tools);
-  chrome.runtime.sendMessage({ tools, url: location.href });
+  chrome.runtime.sendMessage({ tools, url: window.location.href });
 }
+
+function getLocation(crossOriginIframeWindow) {
+  const promise = new Promise((resolve) => {
+    const listener = ({ data }) => {
+      if (data.action === 'GET_LOCATION_RESPONSE') {
+        window.removeEventListener('message', listener);
+        resolve(data.location);
+      }
+    };
+    window.addEventListener('message', listener);
+  });
+  crossOriginIframeWindow.postMessage({ action: 'GET_LOCATION' }, '*');
+  return promise;
+}
+
+window.addEventListener('message', ({ data, origin, source }) => {
+  if (data.action === 'GET_LOCATION') {
+    const location = window.location.href;
+    source.postMessage({ action: 'GET_LOCATION_RESPONSE', location }, origin);
+  }
+});
 
 window.addEventListener('toolactivated', ({ toolName }) => {
   console.debug(`[WebMCP] Tool "${toolName}" started execution.`);

--- a/content.js
+++ b/content.js
@@ -34,7 +34,7 @@ chrome.runtime.onMessage.addListener(({ action, name, inputArgs, location }, _, 
       let promise;
       if ('executeTool' in navigator.modelContext) {
         promise = navigator.modelContext.getTools().then((tools) => {
-          const tool = tools.find((t) => t.name === name && t.window.location.href === location);
+          const tool = tools.find((t) => t.name === name && t.window === window);
           return navigator.modelContext.executeTool(tool, inputArgs);
         });
       } else {

--- a/content.js
+++ b/content.js
@@ -12,7 +12,11 @@ chrome.runtime.onMessage.addListener(({ action, name, inputArgs }, _, reply) => 
     }
     if (action == 'LIST_TOOLS') {
       listTools();
-      if ('ontoolchange' in navigator.modelContextTesting.__proto__) {
+      if ('ontoolchange' in navigator.modelContext) {
+        navigator.modelContext.addEventListener('toolchange', listTools);
+        return;
+      }
+      if ('ontoolchange' in navigator.modelContextTesting) {
         navigator.modelContextTesting.addEventListener('toolchange', listTools);
         return;
       }
@@ -57,8 +61,13 @@ chrome.runtime.onMessage.addListener(({ action, name, inputArgs }, _, reply) => 
   }
 });
 
-function listTools() {
-  const tools = navigator.modelContextTesting.listTools();
+async function listTools() {
+  let tools;
+  if ('getTools' in navigator.modelContext) {
+    tools = await navigator.modelContext.getTools();
+  } else {
+    tools = navigator.modelContextTesting.listTools();
+  }
   console.debug(`[WebMCP] Got ${tools.length} tools`, tools);
   chrome.runtime.sendMessage({ tools, url: location.href });
 }

--- a/content.js
+++ b/content.js
@@ -77,8 +77,8 @@ async function listTools() {
     tools = tools.map((tool) => {
       return {
         description: tool.description,
-        name: tool.name,
         inputSchema: tool.inputSchema,
+        name: tool.name,
         location: tool.window.location.href,
       };
     });

--- a/content.js
+++ b/content.js
@@ -78,6 +78,8 @@ async function listTools() {
       return {
         description: tool.description,
         inputSchema: tool.inputSchema,
+        readOnlyHint: tool.annotations?.readOnlyHint ? '✓' : undefined,
+        untrustedContentHint: tool.annotations?.untrustedContentHint ? '✓' : undefined,
         name: tool.name,
         location: tool.window.location.href,
       };

--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,8 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
+      "all_frames": true,
+      "match_about_blank": true,
       "runAt": "document_start",
       "js": ["content.js"]
     }

--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,7 @@
   "name": "WebMCP - Model Context Tool Inspector",
   "description": "Inspect, monitor, and execute WebMCP tools manually or with Gemini",
   "version": "1.9.5",
+  "minimum_chrome_version": "148.0.7778.56",
   "permissions": ["sidePanel", "activeTab", "scripting"],
   "host_permissions": ["<all_urls>"],
   "update_url": "https://clients2.google.com/service/update2/crx",

--- a/sidebar.js
+++ b/sidebar.js
@@ -43,9 +43,10 @@ let lastSuggestedUserPrompt = '';
 
 // Listen for the results coming back from content.js
 chrome.runtime.onMessage.addListener(async ({ message, tools, url }, sender) => {
+  if (sender.frameId !== 0) return;
+
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   if (sender.tab && sender.tab.id !== tab.id) return;
-  if (sender.frameId !== 0) return;
 
   tbody.innerHTML = '';
   thead.innerHTML = '';

--- a/sidebar.js
+++ b/sidebar.js
@@ -45,6 +45,7 @@ let lastSuggestedUserPrompt = '';
 chrome.runtime.onMessage.addListener(async ({ message, tools, url }, sender) => {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   if (sender.tab && sender.tab.id !== tab.id) return;
+  if (sender.frameId !== 0) return;
 
   tbody.innerHTML = '';
   thead.innerHTML = '';
@@ -76,6 +77,7 @@ chrome.runtime.onMessage.addListener(async ({ message, tools, url }, sender) => 
 
   const keys = Object.keys(tools[0]);
   keys.forEach((key) => {
+    if (key === 'location') return;
     const th = document.createElement('th');
     th.textContent = key;
     thead.appendChild(th);
@@ -84,6 +86,7 @@ chrome.runtime.onMessage.addListener(async ({ message, tools, url }, sender) => 
   tools.forEach((item) => {
     const row = document.createElement('tr');
     keys.forEach((key) => {
+      if (key === 'location') return;
       const td = document.createElement('td');
       try {
         td.innerHTML = `<pre>${JSON.stringify(JSON.parse(item[key]), '', '  ')}</pre>`;
@@ -97,7 +100,11 @@ chrome.runtime.onMessage.addListener(async ({ message, tools, url }, sender) => 
     const option = document.createElement('option');
     option.textContent = `"${item.name}"`;
     option.value = item.name;
+    if (new Set(tools.map((t) => t.location)).size > 1) {
+      option.textContent += ` | ${item.location || ''}`;
+    }
     option.dataset.inputSchema = item.inputSchema || '{}';
+    option.dataset.location = item.location || '';
     toolNames.appendChild(option);
   });
   updateDefaultValueForInputArgs();
@@ -246,15 +253,17 @@ async function promptAI() {
       finalResponseGiven = true;
     } else {
       const toolResponses = [];
-      for (const { name, args } of functionCalls) {
+      for (const { name: name, args } of functionCalls) {
+        const [locationIndex, toolName] = name.split(/_(.*)/s)[1].split(/_(.*)/s);
+        const location = currentTools[locationIndex].location;
         const inputArgs = JSON.stringify(args);
-        logPrompt(`AI calling tool "${name}" with ${inputArgs}`);
+        logPrompt(`AI calling tool "${toolName}" with ${inputArgs}`);
         try {
-          const result = await executeTool(tab.id, name, inputArgs);
+          const result = await executeTool(tab.id, toolName, inputArgs, location);
           toolResponses.push({ functionResponse: { name, response: { result } } });
-          logPrompt(`Tool "${name}" result: ${result}`);
+          logPrompt(`Tool "${toolName}" result: ${result}`);
         } catch (e) {
-          logPrompt(`⚠️ Error executing tool "${name}": ${e.message}`);
+          logPrompt(`⚠️ Error executing tool "${toolName}": ${e.message}`);
           toolResponses.push({
             functionResponse: { name, response: { error: e.message } },
           });
@@ -299,17 +308,19 @@ executeBtn.onclick = async () => {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   const name = toolNames.selectedOptions[0].value;
   const inputArgs = inputArgsText.value;
-  toolResults.textContent = await executeTool(tab.id, name, inputArgs).catch(
+  const location = toolNames.selectedOptions[0].dataset.location;
+  toolResults.textContent = await executeTool(tab.id, name, inputArgs, location).catch(
     (error) => `⚠️ Error: "${error}"`,
   );
 };
 
-async function executeTool(tabId, name, inputArgs) {
+async function executeTool(tabId, name, inputArgs, location) {
   try {
     const result = await chrome.tabs.sendMessage(tabId, {
       action: 'EXECUTE_TOOL',
       name,
       inputArgs,
+      location,
     });
     if (result !== null) return result;
   } catch (error) {
@@ -320,6 +331,7 @@ async function executeTool(tabId, name, inputArgs) {
   await waitForPageLoad(tabId);
   return await chrome.tabs.sendMessage(tabId, {
     action: 'GET_CROSS_DOCUMENT_SCRIPT_TOOL_RESULT',
+    location,
   });
 }
 
@@ -359,8 +371,9 @@ function getConfig() {
   ];
 
   const functionDeclarations = currentTools.map((tool) => {
+    const locationIndex = currentTools.findIndex((t) => t.location === tool.location);
     return {
-      name: tool.name,
+      name: `_${locationIndex}_${tool.name}`,
       description: tool.description,
       parametersJsonSchema: tool.inputSchema
         ? JSON.parse(tool.inputSchema)

--- a/sidebar.js
+++ b/sidebar.js
@@ -27,7 +27,7 @@ const advancedSection = document.getElementById('advancedSection');
 (async () => {
   try {
     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-    await chrome.tabs.sendMessage(tab.id, { action: 'LIST_TOOLS' });
+    await chrome.tabs.sendMessage(tab.id, { action: 'LIST_TOOLS' }, { frameId: 0 });
   } catch (error) {
     const statusDiv = document.getElementById('status');
     statusDiv.textContent = error;
@@ -43,7 +43,7 @@ let lastSuggestedUserPrompt = '';
 
 // Listen for the results coming back from content.js
 chrome.runtime.onMessage.addListener(async ({ message, tools, url }, sender) => {
-  if (sender.frameId !== 0) return;
+  if (sender.frameId && sender.frameId !== 0) return;
 
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   if (sender.tab && sender.tab.id !== tab.id) return;
@@ -77,7 +77,7 @@ chrome.runtime.onMessage.addListener(async ({ message, tools, url }, sender) => 
   copyToClipboard.hidden = false;
 
   const KEYS = ['description', 'inputSchema', 'readOnlyHint', 'untrustedContentHint', 'name'];
-  const keys = KEYS.filter(key => tools.some(tool => key in tool));
+  const keys = KEYS.filter((key) => tools.some((tool) => key in tool));
   keys.forEach((key) => {
     const th = document.createElement('th');
     th.textContent = key;

--- a/sidebar.js
+++ b/sidebar.js
@@ -253,19 +253,19 @@ async function promptAI() {
       finalResponseGiven = true;
     } else {
       const toolResponses = [];
-      for (const { name: name, args } of functionCalls) {
-        const [locationIndex, toolName] = name.split(/_(.*)/s)[1].split(/_(.*)/s);
+      for (const { name: toolName, args } of functionCalls) {
+        const [locationIndex, name] = toolName.split(/_(.*)/s)[1].split(/_(.*)/s);
         const location = currentTools[locationIndex].location;
         const inputArgs = JSON.stringify(args);
-        logPrompt(`AI calling tool "${toolName}" with ${inputArgs}`);
+        logPrompt(`AI calling tool "${name}" with ${inputArgs}`);
         try {
-          const result = await executeTool(tab.id, toolName, inputArgs, location);
-          toolResponses.push({ functionResponse: { name, response: { result } } });
-          logPrompt(`Tool "${toolName}" result: ${result}`);
+          const result = await executeTool(tab.id, name, inputArgs, location);
+          toolResponses.push({ functionResponse: { name: toolName, response: { result } } });
+          logPrompt(`Tool "${name}" result: ${result}`);
         } catch (e) {
-          logPrompt(`⚠️ Error executing tool "${toolName}": ${e.message}`);
+          logPrompt(`⚠️ Error executing tool "${name}": ${e.message}`);
           toolResponses.push({
-            functionResponse: { name, response: { error: e.message } },
+            functionResponse: { name: toolName, response: { error: e.message } },
           });
         }
       }

--- a/sidebar.js
+++ b/sidebar.js
@@ -75,17 +75,8 @@ chrome.runtime.onMessage.addListener(async ({ message, tools, url }, sender) => 
   executeBtn.disabled = false;
   copyToClipboard.hidden = false;
 
-  const KEYS = [
-    'description',
-    'inputSchema',
-    'readOnlyHint',
-    'untrustedContentHint',
-    'name',
-  ];
-  let keys = [...new Set(tools.flatMap((tool) => Object.keys(tool)))];
-  keys = [...keys].sort((a, b) => {
-    return KEYS.indexOf(a) - KEYS.indexOf(b);
-  });
+  const KEYS = ['description', 'inputSchema', 'readOnlyHint', 'untrustedContentHint', 'name'];
+  const keys = KEYS.filter(key => tools.some(tool => key in tool));
   keys.forEach((key) => {
     const th = document.createElement('th');
     th.textContent = key;

--- a/sidebar.js
+++ b/sidebar.js
@@ -23,7 +23,7 @@ const apiKeyBtn = document.getElementById('apiKeyBtn');
 const promptResults = document.getElementById('promptResults');
 const advancedSection = document.getElementById('advancedSection');
 
-// Inject content script first.
+// First, request list of tools from content script living in top-level frame.
 (async () => {
   try {
     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });

--- a/sidebar.js
+++ b/sidebar.js
@@ -75,9 +75,18 @@ chrome.runtime.onMessage.addListener(async ({ message, tools, url }, sender) => 
   executeBtn.disabled = false;
   copyToClipboard.hidden = false;
 
-  const keys = Object.keys(tools[0]);
+  const KEYS = [
+    'description',
+    'inputSchema',
+    'readOnlyHint',
+    'untrustedContentHint',
+    'name',
+  ];
+  let keys = [...new Set(tools.flatMap((tool) => Object.keys(tool)))];
+  keys = [...keys].sort((a, b) => {
+    return KEYS.indexOf(a) - KEYS.indexOf(b);
+  });
   keys.forEach((key) => {
-    if (key === 'location') return;
     const th = document.createElement('th');
     th.textContent = key;
     thead.appendChild(th);
@@ -86,7 +95,6 @@ chrome.runtime.onMessage.addListener(async ({ message, tools, url }, sender) => 
   tools.forEach((item) => {
     const row = document.createElement('tr');
     keys.forEach((key) => {
-      if (key === 'location') return;
       const td = document.createElement('td');
       try {
         td.innerHTML = `<pre>${JSON.stringify(JSON.parse(item[key]), '', '  ')}</pre>`;

--- a/sidebar.js
+++ b/sidebar.js
@@ -97,7 +97,7 @@ chrome.runtime.onMessage.addListener(async ({ message, tools, url }, sender) => 
     const option = document.createElement('option');
     option.textContent = `"${item.name}"`;
     option.value = item.name;
-    option.dataset.inputSchema = item.inputSchema;
+    option.dataset.inputSchema = item.inputSchema || '{}';
     toolNames.appendChild(option);
   });
   updateDefaultValueForInputArgs();


### PR DESCRIPTION
This PR updates the extension to discover and execute tools across all iframes:
- Migrates to `navigator.modelContext.getTools()`, `navigator.modelContext.executeTool()`, and the `ontoolchange` event, with fallbacks for experimental testing APIs.
- Enabled content script injection across all frames (including cross-origin) and 'about:blank' pages.
- Implemented basic location-aware tool indexing for Gemini function calls to prevent naming collisions in multi-frame environments.
- Switched from `getCrossDocumentScriptToolResult()` to `document.querySelector('script[type="application/ld+json"]')?.textContent`
- Display tool annotations properly in sidebar
- Remove registerToolsChangedCallback support and increased min chrome version support.

Note that we can't submit it yet because of https://chromium-review.googlesource.com/c/chromium/src/+/7817087. I'm not sure how to detect it properly this.