### PR TITLE
Add AmiVoice speech recognition

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 3,
-  "name": "WebMCP - Model Context Tool Inspector",
-  "description": "Inspect, monitor, and execute WebMCP tools manually or with Gemini",
+  "name": "WebMCP Voice Inspector",
+  "description": "WebMCP tool inspector with AmiVoice speech recognition",
   "version": "1.9.5",
-  "permissions": ["sidePanel", "activeTab", "scripting"],
+  "permissions": ["sidePanel", "activeTab", "scripting", "microphone"],
   "host_permissions": ["<all_urls>"],
   "update_url": "https://clients2.google.com/service/update2/crx",
   "action": {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "model-context-tool-inspector",
+  "name": "voice-web-mcp",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/sidebar.html
+++ b/sidebar.html
@@ -34,6 +34,20 @@
       <h2 class="collapsible-header">Interact with the Page</h2>
       <div class="section-content">
 
+      <!-- Voice Control -->
+      <div class="form-group">
+        <div class="label-with-button">
+          <label>Voice Input (AmiVoice)</label>
+          <button id="amivoiceKeyBtn" class="secondary" style="position:static;width:auto;height:auto;font-size:0.7rem;padding:4px 8px;">Set APPKEY</button>
+        </div>
+        <div id="voiceStatus" class="voice-status">待機中</div>
+        <div style="display:flex;gap:6px;margin-top:6px;">
+          <button id="voiceStartBtn" class="secondary" disabled>🎙 Start</button>
+          <button id="voiceStopBtn" class="secondary" disabled>■ Stop</button>
+        </div>
+        <div id="voiceResult" class="voice-result"></div>
+      </div>
+
       <div class="form-group">
         <div class="label-with-button">
           <label for="userPromptText">User Prompt</label>
@@ -61,6 +75,7 @@
         <button id="traceBtn" class="secondary">Copy trace</button>
       </div>
 
+
       <pre id="promptResults"></pre>
 
       <div class="form-group">
@@ -81,5 +96,6 @@
       </div>
     </div>
     <script type="module" src="sidebar.js"></script>
+    <script type="module" src="voice.js"></script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -300,6 +300,31 @@ dialog::backdrop {
   width: auto;
 }
 
+/* Voice Control */
+.voice-status {
+  font-size: 0.75rem;
+  color: #6b7280;
+  margin-top: 4px;
+}
+
+.voice-result {
+  margin-top: 8px;
+  padding: 6px 8px;
+  background: #f3f4f6;
+  border-radius: 4px;
+  font-size: 0.8125rem;
+  min-height: 1.5rem;
+  color: #111;
+  word-break: break-all;
+}
+
+@media (prefers-color-scheme: dark) {
+  .voice-result {
+    background: #262626;
+    color: #e5e5e5;
+  }
+}
+
 @media (prefers-color-scheme: dark) {
   body {
     background-color: #121212;

--- a/voice.js
+++ b/voice.js
@@ -1,0 +1,187 @@
+/**
+ * AmiVoice WebSocket speech recognition for WebMCP Voice Inspector.
+ *
+ * Connects to AmiVoice, streams mic audio, and puts the final recognized
+ * text into the existing #userPromptText textarea.
+ */
+
+const ENDPOINT = 'wss://acp-api-nolog.amivoice.com/v1/';
+const ENGINE = '-a-general';
+const AUDIO_FORMAT = 'audio/x-pcm;bit=16;rate=16000;channels=1';
+const SAMPLE_RATE = 16000;
+const CHUNK_SIZE = 4096;
+
+const startBtn = document.getElementById('voiceStartBtn');
+const stopBtn = document.getElementById('voiceStopBtn');
+const statusDiv = document.getElementById('voiceStatus');
+const resultDiv = document.getElementById('voiceResult');
+const userPromptText = document.getElementById('userPromptText');
+const amivoiceKeyBtn = document.getElementById('amivoiceKeyBtn');
+
+function getAppKey() {
+  return localStorage.amivoiceKey || '';
+}
+
+amivoiceKeyBtn.onclick = () => {
+  const key = prompt('AmiVoice APPKEY を入力してください', getAppKey());
+  if (key == null) return;
+  localStorage.amivoiceKey = key;
+  updateUI();
+};
+
+function updateUI() {
+  const hasKey = !!getAppKey();
+  startBtn.disabled = !hasKey;
+  amivoiceKeyBtn.textContent = hasKey ? 'Update APPKEY' : 'Set APPKEY';
+}
+updateUI();
+
+// Float32 PCM → Int16 PCM
+function encodeToInt16(float32) {
+  const int16 = new Int16Array(float32.length);
+  for (let i = 0; i < float32.length; i++) {
+    const s = Math.max(-1, Math.min(1, float32[i]));
+    int16[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
+  }
+  return int16.buffer;
+}
+
+let ws = null;
+let audioCtx = null;
+let stream = null;
+let processor = null;
+
+function setStatus(text, color) {
+  statusDiv.textContent = text;
+  statusDiv.style.color = color || '';
+}
+
+async function startRecognition() {
+  const appKey = getAppKey();
+  if (!appKey) {
+    alert('AmiVoice APPKEY が未設定です。');
+    return;
+  }
+
+  startBtn.disabled = true;
+  stopBtn.disabled = true;
+  resultDiv.textContent = '';
+  setStatus('マイク権限取得中...', '#f0a500');
+
+  try {
+    stream = await navigator.mediaDevices.getUserMedia({
+      audio: { sampleRate: SAMPLE_RATE, channelCount: 1, echoCancellation: true },
+    });
+  } catch (e) {
+    setStatus('マイク権限エラー: ' + e.message, 'red');
+    startBtn.disabled = false;
+    return;
+  }
+
+  setStatus('AmiVoice 接続中...', '#f0a500');
+
+  ws = new WebSocket(ENDPOINT);
+  ws.binaryType = 'arraybuffer';
+
+  ws.onopen = () => {
+    ws.send(`s ${AUDIO_FORMAT} ${ENGINE} ${appKey}`);
+  };
+
+  ws.onmessage = (event) => {
+    if (typeof event.data !== 'string') return;
+    const type = event.data[0];
+    const payload = event.data.slice(2);
+
+    if (type === 's') {
+      setStatus('録音中 🔴', '#e53e3e');
+      stopBtn.disabled = false;
+      startAudio();
+    } else if (type === 'A') {
+      const text = parseResultText(payload);
+      if (text) {
+        resultDiv.textContent = text;
+        userPromptText.value = (userPromptText.value ? userPromptText.value + ' ' : '') + text;
+      }
+    } else if (type === 'p') {
+      const text = parseResultText(payload);
+      if (text) resultDiv.textContent = text + '...';
+    } else if (type === 'e') {
+      setStatus('エラー: ' + payload, 'red');
+      cleanup();
+    } else if (type === 'C') {
+      cleanup();
+    }
+  };
+
+  ws.onerror = () => {
+    setStatus('WebSocket エラー', 'red');
+    cleanup();
+  };
+
+  ws.onclose = () => {
+    if (statusDiv.textContent === '録音中 🔴') setStatus('切断', '#888');
+    cleanup();
+  };
+}
+
+function startAudio() {
+  audioCtx = new AudioContext({ sampleRate: SAMPLE_RATE });
+  const source = audioCtx.createMediaStreamSource(stream);
+  processor = audioCtx.createScriptProcessor(CHUNK_SIZE, 1, 1);
+
+  processor.onaudioprocess = (e) => {
+    if (ws?.readyState === WebSocket.OPEN) {
+      ws.send(encodeToInt16(e.inputBuffer.getChannelData(0)));
+    }
+  };
+
+  source.connect(processor);
+  processor.connect(audioCtx.destination);
+}
+
+async function stopRecognition() {
+  stopBtn.disabled = true;
+  setStatus('認識中...', '#3182ce');
+
+  if (ws?.readyState === WebSocket.OPEN) ws.send('e');
+
+  processor?.disconnect();
+  processor = null;
+  if (audioCtx) { await audioCtx.close(); audioCtx = null; }
+  stream?.getTracks().forEach((t) => t.stop());
+  stream = null;
+}
+
+function cleanup() {
+  processor?.disconnect();
+  processor = null;
+  audioCtx?.close().catch(() => {});
+  audioCtx = null;
+  stream?.getTracks().forEach((t) => t.stop());
+  stream = null;
+
+  startBtn.disabled = !getAppKey();
+  stopBtn.disabled = true;
+
+  if (!statusDiv.textContent.startsWith('エラー') &&
+      !statusDiv.textContent.startsWith('マイク権限') &&
+      !statusDiv.textContent.startsWith('WebSocket')) {
+    setStatus('待機中');
+  }
+}
+
+function parseResultText(payload) {
+  try {
+    const json = JSON.parse(payload);
+    if (typeof json.text === 'string') return json.text;
+    if (Array.isArray(json.results)) {
+      return json.results.flatMap((r) => r.tokens?.map((t) => t.written) ?? []).join('');
+    }
+  } catch {
+    return payload.trim();
+  }
+  return '';
+}
+
+startBtn.onclick = () => void startRecognition();
+stopBtn.onclick = () => void stopRecognition();


### PR DESCRIPTION
## Summary

- AmiVoice WebSocket を使った音声認識を side panel に追加
- マイクボタン（Start / Stop）、認識中テキスト表示、APPKEY 設定を追加
- 認識確定テキストを既存の User Prompt 欄に自動挿入し、既存の Gemini フローをそのまま利用できる

## Changes

- `manifest.json`: 拡張機能名・説明を更新、`microphone` パーミッション追加
- `sidebar.html`: Voice Input セクション（マイクボタン・ステータス・結果表示）追加
- `styles.css`: Voice Control 用スタイル追加
- `voice.js`: 新規追加（AmiVoice WebSocket 接続・マイク録音・PCM エンコード）

## Known issue

Side panel での `getUserMedia()` が Permission dismissed になる環境あり（調査中）。