### PR TITLE
Fix EXECUTE_TOOL sent to all frames causing "Tool not found" on pages with frames

### DIFF
--- a/sidebar.js
+++ b/sidebar.js
@@ -319,12 +319,17 @@ executeBtn.onclick = async () => {
 
 async function executeTool(tabId, name, inputArgs, location) {
   try {
+    // Send only to the frame that owns the tool.
+    // If location matches the top-level URL or is empty, target frameId 0.
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    const options = (!location || location === tab.url) ? { frameId: 0 } : {};
+    
     const result = await chrome.tabs.sendMessage(tabId, {
       action: 'EXECUTE_TOOL',
       name,
       inputArgs,
       location,
-    });
+    }, options);
     if (result !== null) return result;
   } catch (error) {
     if (!error.message.includes('message channel is closed')) throw error;


### PR DESCRIPTION
When a page contains iframes (e.g. auth iframes, analytics, third-party widgets), the EXECUTE_TOOL message is broadcast to all frames via `chrome.tabs.sendMessage` without specifying a `frameId`. The iframe's content script receives the message first and calls `navigator.modelContextTesting.executeTool()` in its own context (where the tool is not registered) returning "Tool not found" before the top-level frame can respond.

This makes tool execution fail on any page that has at least one iframe, even though the tool is correctly registered and visible via `LIST_TOOLS`.