### PR TITLE
Get tools from all origins

### DIFF
--- a/background.js
+++ b/background.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { getIframeOrigins } from './utils.js';
+
 // Allows users to open the side panel by clicking the action icon.
 chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
 
@@ -28,7 +30,9 @@ async function updateBadge(tabId) {
   if (tab.id !== tabId) return;
   chrome.action.setBadgeText({ text: '', tabId });
   chrome.action.setBadgeBackgroundColor({ color: '#2563eb' });
-  chrome.tabs.sendMessage(tabId, { action: 'LIST_TOOLS' }, { frameId: 0 }).catch(({ message }) => {
+  const fromOrigins = await getIframeOrigins(tab.id);
+  const message = { action: 'LIST_TOOLS', fromOrigins };
+  chrome.tabs.sendMessage(tabId, message, { frameId: 0 }).catch(({ message }) => {
     chrome.runtime.sendMessage({ message });
   });
 }

--- a/content.js
+++ b/content.js
@@ -7,15 +7,16 @@ console.debug(`[WebMCP] Content script injected in ${window.location.href}`);
 
 const modelContext = document.modelContext || navigator.modelContext;
 
-chrome.runtime.onMessage.addListener(({ action, name, inputArgs, location }, _, reply) => {
+chrome.runtime.onMessage.addListener((message, _, reply) => {
+  const { action, name, inputArgs, location, fromOrigins } = message;
   try {
     if (!navigator.modelContextTesting && !modelContext) {
       throw new Error('Error: You must run Chrome with the "WebMCP for testing" flag enabled.');
     }
     if (action == 'LIST_TOOLS') {
-      listTools();
+      listTools(fromOrigins);
       if ('ontoolchange' in modelContext) {
-        modelContext.addEventListener('toolchange', listTools);
+        modelContext.addEventListener('toolchange', listTools.bind(null, fromOrigins));
         return;
       }
       navigator.modelContextTesting.addEventListener('toolchange', listTools);
@@ -68,10 +69,10 @@ chrome.runtime.onMessage.addListener(({ action, name, inputArgs, location }, _, 
   }
 });
 
-async function listTools() {
+async function listTools(fromOrigins) {
   let tools = [];
   if ('getTools' in modelContext) {
-    for (const tool of await modelContext.getTools()) {
+    for (const tool of await modelContext.getTools({ fromOrigins })) {
       let location;
       try {
         location = tool.window.location.href;

--- a/manifest.json
+++ b/manifest.json
@@ -4,12 +4,13 @@
   "description": "Inspect, monitor, and execute WebMCP tools manually or with Gemini",
   "version": "1.9.7",
   "minimum_chrome_version": "148.0.7778.56",
-  "permissions": ["sidePanel", "activeTab", "scripting"],
+  "permissions": ["sidePanel", "activeTab", "scripting", "webNavigation"],
   "host_permissions": ["<all_urls>"],
   "update_url": "https://clients2.google.com/service/update2/crx",
   "action": {},
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "type": "module"
   },
   "side_panel": {
     "default_path": "sidebar.html"

--- a/sidebar.js
+++ b/sidebar.js
@@ -4,6 +4,7 @@
  */
 
 import { GoogleGenAI } from './js-genai.js';
+import { getIframeOrigins } from './utils.js';
 
 const statusDiv = document.getElementById('status');
 const tbody = document.getElementById('tableBody');
@@ -27,7 +28,8 @@ const advancedSection = document.getElementById('advancedSection');
 (async () => {
   try {
     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-    await chrome.tabs.sendMessage(tab.id, { action: 'LIST_TOOLS' }, { frameId: 0 });
+    const fromOrigins = await getIframeOrigins(tab.id);
+    await chrome.tabs.sendMessage(tab.id, { action: 'LIST_TOOLS', fromOrigins }, { frameId: 0 });
   } catch (error) {
     const statusDiv = document.getElementById('status');
     statusDiv.textContent = error;

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+async function getIframeOrigins(tabId) {
+  const frames = await chrome.webNavigation.getAllFrames({ tabId });
+
+  // Extract origins, ignoring the top-level frame (frameId === 0)
+  const origins = frames
+    .filter((frame) => frame.frameId !== 0)
+    .map((frame) => {
+      try {
+        return new URL(frame.url).origin;
+      } catch (e) {
+        return 'null';
+      }
+    })
+    .filter((origin) => origin !== 'null');
+
+  return [...new Set(origins)];
+}
+
+export { getIframeOrigins };


### PR DESCRIPTION
This PR makes sure tools from cross-origin iframes are displayed in the extension following https://chromium-review.googlesource.com/c/chromium/src/+/7880667. It does so by getting all iframes origins using the `webNavigation.getAllFrames` extension API since `*` is not allowed in WebMCP.

FYI documentation has been updated as well: https://developer.chrome.com/docs/ai/webmcp/imperative-api#discover-tools