### PR TITLE
Make postinstall script Windows compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env.json
 js-genai.js
+node_modules/*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "postinstall": "npx esbuild ./node_modules/@google/genai/dist/web/index.mjs --bundle --format=esm --outfile=js-genai.js && rm -rf node_modules"
+    "postinstall": "npx esbuild ./node_modules/@google/genai/dist/web/index.mjs --bundle --format=esm --outfile=js-genai.js && node -e \"require('fs').rmSync('node_modules', { recursive: true, force: true })\""
   },
   "dependencies": {
     "@google/genai": "^1.38.0"


### PR DESCRIPTION
1. Replaces `rm` with node specific removal script in postinstall to make it platform agnostic
2. also adds node_modules to gitignore, git indexes and unindexes this folder through the whole install process using system resources without any gains