### PR TITLE
Refactor tool discovery and execution to use frameId

### DIFF
--- a/background.js
+++ b/background.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getIframeOrigins } from './utils.js';
+import { getAllFrameOrigins } from './utils.js';
 
 // Allows users to open the side panel by clicking the action icon.
 chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
@@ -24,20 +24,43 @@ chrome.runtime.onInstalled.addListener(async () => {
 // Update badge text with the number of tools per tab.
 chrome.tabs.onActivated.addListener(({ tabId }) => updateBadge(tabId));
 chrome.tabs.onUpdated.addListener((tabId) => updateBadge(tabId));
+chrome.webNavigation.onCompleted.addListener(({ tabId }) => updateBadge(tabId));
 
 async function updateBadge(tabId) {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   if (tab.id !== tabId) return;
   chrome.action.setBadgeText({ text: '', tabId });
   chrome.action.setBadgeBackgroundColor({ color: '#2563eb' });
-  const fromOrigins = await getIframeOrigins(tab.id);
+  const fromOrigins = await getAllFrameOrigins(tab.id);
   const message = { action: 'LIST_TOOLS', fromOrigins };
   chrome.tabs.sendMessage(tabId, message, { frameId: 0 }).catch(({ message }) => {
     chrome.runtime.sendMessage({ message });
   });
 }
 
-chrome.runtime.onMessage.addListener(({ tools }, { tab }) => {
+chrome.runtime.onMessage.addListener(async ({ action, tools }, { tab, origin }, sendResponse) => {
+  if (action == 'INJECT_GET_LOCATION_LISTENER') {
+    await chrome.scripting.executeScript({
+      target: { tabId: tab.id, allFrames: true },
+      func: getLocation,
+    });
+    return;
+  }
+  if (action == 'GET_LOCATION') {
+    sendResponse(origin);
+    return;
+  }
   const text = tools?.length ? `${tools.length}` : '';
   chrome.action.setBadgeText({ text, tabId: tab.id });
 });
+
+// Listen for location requests from an embedded frame and sends it back.
+function getLocation() {
+  if (window == window.top) return;
+  window.onmessage = async ({ data, source, origin }) => {
+    if (data.action === 'GET_LOCATION') {
+      const location = await chrome.runtime.sendMessage({ action: 'GET_LOCATION' });
+      source.postMessage({ action: 'GET_LOCATION_RESPONSE', location }, origin);
+    }
+  };
+}

--- a/background.js
+++ b/background.js
@@ -38,29 +38,32 @@ async function updateBadge(tabId) {
   });
 }
 
-chrome.runtime.onMessage.addListener(async ({ action, tools }, { tab, origin }, sendResponse) => {
-  if (action == 'INJECT_GET_LOCATION_LISTENER') {
-    await chrome.scripting.executeScript({
+chrome.runtime.onMessage.addListener(({ action, tools }, { tab, frameId }, sendResponse) => {
+  if (action == 'INJECT_GET_FRAME_ID') {
+    chrome.scripting.executeScript({
       target: { tabId: tab.id, allFrames: true },
-      func: getLocation,
+      func: getFrameId,
     });
     return;
   }
-  if (action == 'GET_LOCATION') {
-    sendResponse(origin);
+  if (action == 'GET_FRAME_ID') {
+    sendResponse(frameId);
     return;
   }
   const text = tools?.length ? `${tools.length}` : '';
   chrome.action.setBadgeText({ text, tabId: tab.id });
 });
 
-// Listen for location requests from an embedded frame and sends it back.
-function getLocation() {
-  if (window == window.top) return;
+// Listen for frameId requests from a window and sends it back.
+function getFrameId() {
   window.onmessage = async ({ data, source, origin }) => {
-    if (data.action === 'GET_LOCATION') {
-      const location = await chrome.runtime.sendMessage({ action: 'GET_LOCATION' });
-      source.postMessage({ action: 'GET_LOCATION_RESPONSE', location }, origin);
+    if (data.action !== 'GET_FRAME_ID') return;
+    for (let i = 0; i < 10; i++) {
+      const frameId = await chrome.runtime.sendMessage({ action: 'GET_FRAME_ID' });
+      if (frameId != null) {
+        return source.postMessage({ action: 'GET_FRAME_ID_RESPONSE', frameId }, origin);
+      }
     }
+    console.debug('[WebMCP] failed to get frameId after 10 attempts');
   };
 }

--- a/content.js
+++ b/content.js
@@ -6,7 +6,7 @@
 console.debug(`[WebMCP] Content script injected in ${window.location.href}`);
 
 chrome.runtime.onMessage.addListener((message, _, reply) => {
-  const { action, name, inputArgs, location, fromOrigins } = message;
+  const { action, name, inputArgs, fromOrigins } = message;
   try {
     if (!document.modelContext) {
       throw new Error('Error: You must run Chrome with the "WebMCP for testing" flag enabled.');
@@ -16,8 +16,7 @@ chrome.runtime.onMessage.addListener((message, _, reply) => {
       document.modelContext.ontoolchange = debouncedListTools.bind(null, fromOrigins);
     }
     if (action == 'EXECUTE_TOOL') {
-      if (location && location !== window.location.href) return;
-      console.debug(`[WebMCP] Execute tool "${name}" with ${inputArgs} in ${location}`);
+      console.debug(`[WebMCP] Execute tool "${name}" with ${inputArgs} in ${window.location.href}`);
       let targetFrame, loadPromise;
       // Check if this tool is associated with a form target
       const formTarget = document.querySelector(`form[toolname="${name}"]`)?.target;
@@ -32,7 +31,6 @@ chrome.runtime.onMessage.addListener((message, _, reply) => {
         .getTools()
         .then((tools) => {
           const tool = tools.find((t) => t.name === name && t.window === window);
-          if (!tool) throw new Error('NO_TOOL_FOUND');
           return document.modelContext.executeTool(tool, inputArgs);
         })
         .then(async (result) => {
@@ -47,14 +45,11 @@ chrome.runtime.onMessage.addListener((message, _, reply) => {
           }
           reply(result);
         })
-        .catch(({ message }) => {
-          if (message !== 'NO_TOOL_FOUND') reply(JSON.stringify(message));
-        });
+        .catch(({ message }) => reply(JSON.stringify(message)));
       return true;
     }
     if (action == 'GET_CROSS_DOCUMENT_SCRIPT_TOOL_RESULT') {
-      if (location && !window.location.href.startsWith(location)) return;
-      console.debug(`[WebMCP] Get cross document script tool result in ${location}`);
+      console.debug(`[WebMCP] Get cross document script tool result in ${window.location.href}`);
       reply(document.querySelector('script[type="application/ld+json"]')?.textContent);
     }
   } catch ({ message }) {
@@ -71,37 +66,32 @@ function debouncedListTools(fromOrigins) {
 async function listTools(fromOrigins) {
   let tools = [];
   for (const tool of await document.modelContext.getTools({ fromOrigins })) {
-    let location;
-    try {
-      location = tool.window.location.href;
-    } catch {
-      location = await getLocation(tool.window);
-    }
+    const frameId = tool.window == window ? 0 : await getFrameId(tool.window);
     tools.push({
       description: tool.description,
       inputSchema: tool.inputSchema,
       readOnlyHint: tool.annotations?.readOnlyHint ? '✓' : undefined,
       untrustedContentHint: tool.annotations?.untrustedContentHint ? '✓' : undefined,
       name: tool.name,
-      location,
+      frameId,
     });
   }
   console.debug(`[WebMCP] Got ${tools.length} tools`, tools);
   chrome.runtime.sendMessage({ tools, url: window.location.href });
 }
 
-async function getLocation(crossOriginIframeWindow) {
-  await chrome.runtime.sendMessage({ action: 'INJECT_GET_LOCATION_LISTENER' });
+async function getFrameId(targetWindow) {
+  await chrome.runtime.sendMessage({ action: 'INJECT_GET_FRAME_ID' });
   const promise = new Promise((resolve) => {
     const listener = ({ source, data }) => {
-      if (source == crossOriginIframeWindow && data.action === 'GET_LOCATION_RESPONSE') {
+      if (source == targetWindow && data.action === 'GET_FRAME_ID_RESPONSE') {
         window.removeEventListener('message', listener);
-        resolve(data.location);
+        resolve(data.frameId);
       }
     };
     window.addEventListener('message', listener);
   });
-  crossOriginIframeWindow.postMessage({ action: 'GET_LOCATION' }, '*');
+  targetWindow.postMessage({ action: 'GET_FRAME_ID' }, '*');
   return promise;
 }
 

--- a/content.js
+++ b/content.js
@@ -12,8 +12,8 @@ chrome.runtime.onMessage.addListener((message, _, reply) => {
       throw new Error('Error: You must run Chrome with the "WebMCP for testing" flag enabled.');
     }
     if (action == 'LIST_TOOLS') {
-      listTools(fromOrigins);
-      document.modelContext.ontoolchange = listTools.bind(null, fromOrigins);
+      debouncedListTools(fromOrigins);
+      document.modelContext.ontoolchange = debouncedListTools.bind(null, fromOrigins);
     }
     if (action == 'EXECUTE_TOOL') {
       if (location && location !== window.location.href) return;
@@ -32,6 +32,7 @@ chrome.runtime.onMessage.addListener((message, _, reply) => {
         .getTools()
         .then((tools) => {
           const tool = tools.find((t) => t.name === name && t.window === window);
+          if (!tool) throw new Error('NO_TOOL_FOUND');
           return document.modelContext.executeTool(tool, inputArgs);
         })
         .then(async (result) => {
@@ -46,7 +47,9 @@ chrome.runtime.onMessage.addListener((message, _, reply) => {
           }
           reply(result);
         })
-        .catch(({ message }) => reply(JSON.stringify(message)));
+        .catch(({ message }) => {
+          if (message !== 'NO_TOOL_FOUND') reply(JSON.stringify(message));
+        });
       return true;
     }
     if (action == 'GET_CROSS_DOCUMENT_SCRIPT_TOOL_RESULT') {
@@ -58,6 +61,12 @@ chrome.runtime.onMessage.addListener((message, _, reply) => {
     chrome.runtime.sendMessage({ message });
   }
 });
+
+let timeout;
+function debouncedListTools(fromOrigins) {
+  clearTimeout(timeout);
+  timeout = setTimeout(() => listTools(fromOrigins), 100);
+}
 
 async function listTools(fromOrigins) {
   let tools = [];
@@ -81,10 +90,11 @@ async function listTools(fromOrigins) {
   chrome.runtime.sendMessage({ tools, url: window.location.href });
 }
 
-function getLocation(crossOriginIframeWindow) {
+async function getLocation(crossOriginIframeWindow) {
+  await chrome.runtime.sendMessage({ action: 'INJECT_GET_LOCATION_LISTENER' });
   const promise = new Promise((resolve) => {
-    const listener = ({ data }) => {
-      if (data.action === 'GET_LOCATION_RESPONSE') {
+    const listener = ({ source, data }) => {
+      if (source == crossOriginIframeWindow && data.action === 'GET_LOCATION_RESPONSE') {
         window.removeEventListener('message', listener);
         resolve(data.location);
       }
@@ -94,13 +104,6 @@ function getLocation(crossOriginIframeWindow) {
   crossOriginIframeWindow.postMessage({ action: 'GET_LOCATION' }, '*');
   return promise;
 }
-
-window.addEventListener('message', ({ data, origin, source }) => {
-  if (data.action === 'GET_LOCATION') {
-    const location = window.location.href;
-    source.postMessage({ action: 'GET_LOCATION_RESPONSE', location }, origin);
-  }
-});
 
 window.addEventListener('toolactivated', ({ toolName }) => {
   console.debug(`[WebMCP] Tool "${toolName}" started execution.`);

--- a/sidebar.js
+++ b/sidebar.js
@@ -101,13 +101,10 @@ chrome.runtime.onMessage.addListener(async ({ message, tools, url }, sender) => 
     tbody.appendChild(row);
 
     const option = document.createElement('option');
-    option.textContent = `"${item.name}"`;
+    option.textContent = `"${item.name}"${item.frameId !== 0 ? ` (${item.frameId})` : ''}`;
     option.value = item.name;
-    if (new Set(tools.map((t) => t.location)).size > 1) {
-      option.textContent += ` | ${item.location || ''}`;
-    }
     option.dataset.inputSchema = item.inputSchema || '{}';
-    option.dataset.location = item.location || '';
+    option.dataset.frameId = item.frameId;
     toolNames.appendChild(option);
   });
   updateDefaultValueForInputArgs();
@@ -269,12 +266,12 @@ async function promptAI() {
     } else {
       const toolResponses = [];
       for (const { name: toolName, args } of functionCalls) {
-        const [locationIndex, name] = toolName.split(/_(.*)/s)[1].split(/_(.*)/s);
-        const location = currentTools[locationIndex].location;
+        let [frameId, name] = toolName.split(/_(.*)/s)[1].split(/_(.*)/s);
+        frameId = parseInt(frameId);
         const inputArgs = JSON.stringify(args);
         logPrompt(`AI calling tool "${name}" with ${inputArgs}`);
         try {
-          const result = await executeTool(tab, name, inputArgs, location);
+          const result = await executeTool(tab.id, name, inputArgs, frameId);
           toolResponses.push({ functionResponse: { name: toolName, response: { result } } });
           logPrompt(`Tool "${name}" result: ${result}`);
         } catch (e) {
@@ -323,17 +320,18 @@ executeBtn.onclick = async () => {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   const name = toolNames.selectedOptions[0].value;
   const inputArgs = inputArgsText.value;
-  const location = toolNames.selectedOptions[0].dataset.location;
-  toolResults.textContent = await executeTool(tab, name, inputArgs, location).catch(
+  const frameId = parseInt(toolNames.selectedOptions[0].dataset.frameId);
+  toolResults.textContent = await executeTool(tab.id, name, inputArgs, frameId).catch(
     (error) => `⚠️ Error: "${error}"`,
   );
 };
 
-async function executeTool(tab, name, inputArgs, location) {
+async function executeTool(tabId, name, inputArgs, frameId) {
   try {
     const result = await chrome.tabs.sendMessage(
-      tab.id,
-      { action: 'EXECUTE_TOOL', name, inputArgs, location },
+      tabId,
+      { action: 'EXECUTE_TOOL', name, inputArgs },
+      { frameId },
     );
     if (result !== null) return result;
   } catch (error) {
@@ -341,11 +339,12 @@ async function executeTool(tab, name, inputArgs, location) {
   }
   // A navigation was triggered. The result will be on the next document.
   // TODO: Handle case where a new tab is opened.
-  await waitForPageLoad(tab.id);
-  return await chrome.tabs.sendMessage(tab.id, {
-    action: 'GET_CROSS_DOCUMENT_SCRIPT_TOOL_RESULT',
-    location,
-  });
+  await waitForPageLoad(tabId);
+  return await chrome.tabs.sendMessage(
+    tabId,
+    { action: 'GET_CROSS_DOCUMENT_SCRIPT_TOOL_RESULT' },
+    { frameId },
+  );
 }
 
 toolNames.onchange = updateDefaultValueForInputArgs;
@@ -384,9 +383,8 @@ function getConfig() {
   ];
 
   const functionDeclarations = currentTools.map((tool) => {
-    const locationIndex = currentTools.findIndex((t) => t.location === tool.location);
     return {
-      name: `_${locationIndex}_${tool.name}`,
+      name: `_${tool.frameId}_${tool.name}`,
       description: tool.description,
       parametersJsonSchema: tool.inputSchema
         ? JSON.parse(tool.inputSchema)

--- a/sidebar.js
+++ b/sidebar.js
@@ -4,7 +4,7 @@
  */
 
 import { GoogleGenAI } from './js-genai.js';
-import { getIframeOrigins } from './utils.js';
+import { getAllFrameOrigins } from './utils.js';
 
 const statusDiv = document.getElementById('status');
 const tbody = document.getElementById('tableBody');
@@ -29,7 +29,7 @@ const suggestUserPromptCheckbox = document.getElementById('suggestUserPromptChec
 (async () => {
   try {
     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-    const fromOrigins = await getIframeOrigins(tab.id);
+    const fromOrigins = await getAllFrameOrigins(tab.id);
     await chrome.tabs.sendMessage(tab.id, { action: 'LIST_TOOLS', fromOrigins }, { frameId: 0 });
   } catch (error) {
     const statusDiv = document.getElementById('status');
@@ -330,13 +330,10 @@ executeBtn.onclick = async () => {
 };
 
 async function executeTool(tab, name, inputArgs, location) {
-  // Target the main frame if no location is specified or it matches the top-level URL
-  const options = !location || location === tab.url ? { frameId: 0 } : {};
   try {
     const result = await chrome.tabs.sendMessage(
       tab.id,
       { action: 'EXECUTE_TOOL', name, inputArgs, location },
-      options,
     );
     if (result !== null) return result;
   } catch (error) {

--- a/utils.js
+++ b/utils.js
@@ -3,12 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-async function getIframeOrigins(tabId) {
+async function getAllFrameOrigins(tabId) {
   const frames = await chrome.webNavigation.getAllFrames({ tabId });
-
-  // Extract origins, ignoring the top-level frame (frameId === 0)
   const origins = frames
-    .filter((frame) => frame.frameId !== 0)
     .map((frame) => {
       try {
         return new URL(frame.url).origin;
@@ -21,4 +18,4 @@ async function getIframeOrigins(tabId) {
   return [...new Set(origins)];
 }
 
-export { getIframeOrigins };
+export { getAllFrameOrigins };


### PR DESCRIPTION
- Switch from URL-based tool identification to `frameId` for more robust targeting across frames.
- Implement a message-passing mechanism to retrieve `frameId` from frames.
- Rename `getIframeOrigins` to `getAllFrameOrigins` and include the top-level frame.
- Add `webNavigation.onCompleted` listener to ensure badge updates after navigation.
- Debounce tool listing in the content script to improve performance.
- Update sidebar to display frame IDs and use them for tool calls.