### PR TITLE
Add Gemini 3.6 flash + Gemini 3.5 flash-lite as model options

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "WebMCP - Model Context Tool Inspector",
   "description": "Inspect, monitor, and execute WebMCP tools manually or with Gemini",
-  "version": "1.9.13",
+  "version": "1.9.12",
   "minimum_chrome_version": "150.0.7861.0",
   "permissions": ["sidePanel", "activeTab", "scripting", "webNavigation"],
   "host_permissions": ["<all_urls>"],

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "WebMCP - Model Context Tool Inspector",
   "description": "Inspect, monitor, and execute WebMCP tools manually or with Gemini",
-  "version": "1.9.12",
+  "version": "1.9.13",
   "minimum_chrome_version": "150.0.7861.0",
   "permissions": ["sidePanel", "activeTab", "scripting", "webNavigation"],
   "host_permissions": ["<all_urls>"],

--- a/sidebar.html
+++ b/sidebar.html
@@ -53,16 +53,8 @@
           <span>Gemini 3.1 Flash-Lite</span>
         </label>
         <label class="model-option">
-          <input type="radio" name="model" value="gemini-3.5-flash-lite">
-          <span>Gemini 3.5 Flash-Lite</span>
-        </label>
-        <label class="model-option">
           <input type="radio" name="model" value="gemini-3.5-flash">
           <span>Gemini 3.5 Flash</span>
-        </label>
-        <label class="model-option">
-          <input type="radio" name="model" value="gemini-3.6-flash">
-          <span>Gemini 3.6 Flash</span>
         </label>
         <div class="menu-label">Advanced Options</div>
         <label class="model-option">

--- a/sidebar.html
+++ b/sidebar.html
@@ -53,8 +53,16 @@
           <span>Gemini 3.1 Flash-Lite</span>
         </label>
         <label class="model-option">
+          <input type="radio" name="model" value="gemini-3.5-flash-lite">
+          <span>Gemini 3.5 Flash-Lite</span>
+        </label>
+        <label class="model-option">
           <input type="radio" name="model" value="gemini-3.5-flash">
           <span>Gemini 3.5 Flash</span>
+        </label>
+        <label class="model-option">
+          <input type="radio" name="model" value="gemini-3.6-flash">
+          <span>Gemini 3.6 Flash</span>
         </label>
         <div class="menu-label">Advanced Options</div>
         <label class="model-option">

--- a/sidebar.js
+++ b/sidebar.js
@@ -162,7 +162,7 @@ async function initGenAI() {
   if (localStorage.model === 'gemini-3.1-flash-lite-preview') {
     localStorage.model = 'gemini-3.1-flash-lite';
   }
-  localStorage.model ??= env?.model || 'gemini-3-flash-preview';
+  localStorage.model ??= env?.model || 'gemini-3.6-flash';
   genAI = localStorage.apiKey ? new GoogleGenAI({ apiKey: localStorage.apiKey }) : undefined;
   promptBtn.disabled = !localStorage.apiKey;
   resetBtn.disabled = !localStorage.apiKey;

--- a/sidebar.js
+++ b/sidebar.js
@@ -162,7 +162,7 @@ async function initGenAI() {
   if (localStorage.model === 'gemini-3.1-flash-lite-preview') {
     localStorage.model = 'gemini-3.1-flash-lite';
   }
-  localStorage.model ??= env?.model || 'gemini-3.6-flash';
+  localStorage.model ??= env?.model || 'gemini-3-flash-preview';
   genAI = localStorage.apiKey ? new GoogleGenAI({ apiKey: localStorage.apiKey }) : undefined;
   promptBtn.disabled = !localStorage.apiKey;
   resetBtn.disabled = !localStorage.apiKey;


### PR DESCRIPTION
This adds Gemini 3.6 flash + Gemini 3.5 flash-lite as model options in-place with no other changes in the dropdown. The default fallback was updated to 3.6 flash as well.