### PR TITLE
fix: handle RegisteredTool.inputSchema as an object

### DIFF
--- a/content.js
+++ b/content.js
@@ -71,9 +71,11 @@ async function listTools(fromOrigins) {
   let tools = [];
   for (const tool of await document.modelContext.getTools({ fromOrigins })) {
     const frameId = tool.window == window ? 0 : await getFrameId(tool.window);
+    const inputSchema =
+      typeof tool.inputSchema === 'string' ? tool.inputSchema : JSON.stringify(tool.inputSchema);
     tools.push({
       description: tool.description,
-      inputSchema: tool.inputSchema,
+      inputSchema,
       readOnlyHint: tool.annotations?.readOnlyHint ? '✓' : undefined,
       untrustedContentHint: tool.annotations?.untrustedContentHint ? '✓' : undefined,
       name: tool.name,


### PR DESCRIPTION
Ensure `inputSchema` is serialized to a string when returned as an object from `document.modelContext.getTools()`, aligning with the updated WebMCP specification and Chromium implementation.
    
References:
    - https://chromium-review.googlesource.com/c/chromium/src/+/8248081
    - https://github.com/webmachinelearning/webmcp/pull/241
