### PR TITLE
Handle both parsed and stringified input args for tool execution

### DIFF
--- a/content.js
+++ b/content.js
@@ -33,9 +33,20 @@ chrome.runtime.onMessage.addListener((message, _, reply) => {
       // Execute the experimental tool
       document.modelContext
         .getTools()
-        .then((tools) => {
+        .then(async (tools) => {
           const tool = tools.find((t) => t.name === name && t.window === window);
-          return document.modelContext.executeTool(tool, inputArgs);
+          let result;
+          try {
+            result = await document.modelContext.executeTool(tool, JSON.parse(inputArgs));
+          } catch (e) {
+            // TODO: Remove this when executeTool doesn't accept JSON stringified inputArgs anymore in Chrome Stable.
+            if (e.message.startsWith('Failed to parse input')) {
+              result = await document.modelContext.executeTool(tool, inputArgs);
+            } else {
+              throw e;
+            }
+          }
+          return result;
         })
         .then(async (result) => {
           // If result is null and we have a target frame, wait for the frame to reload.


### PR DESCRIPTION
Updates tool execution in `content.js` to pass parsed input arguments to document.modelContext.executeTool, while retaining backward compatibility for versions of Chrome that still expect a JSON string.
    
References:
    - https://chromium-review.googlesource.com/c/chromium/src/+/8250826
    - https://github.com/webmachinelearning/webmcp/pull/246
